### PR TITLE
feat: remove Sunshine client

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ flatpak, brew, or manually installing them to ~/.local/bin/.
 - OpenRazer: removed for a more minimal base install
 - monaspace fonts: space concerns
 - RamaLama: LLM development is not an objective for this image
+- Sunshine: This build is not oriented towards gaming
 
 ## Credits
 

--- a/packages.json
+++ b/packages.json
@@ -22,6 +22,7 @@
             "ptyxis",
             "python3-ramalama",
             "solaar",
+            "Sunshine",
             "tailscale"
         ]
     }


### PR DESCRIPTION
At some point the client for [Sunshine](https://app.lizardbyte.dev/Sunshine/) was added to base Aurora; there is no need for this in BorealOS and as such has been removed.