### PR TITLE
fix(signing): empty /etc/containers/policy.json due to bad jq command

### DIFF
--- a/build-files/signing.sh
+++ b/build-files/signing.sh
@@ -77,15 +77,15 @@ cat > /etc/containers/policy.json <<< "$(jq '.transports.docker |=. + {
         "signedIdentity": {
             "type": "matchRepository"
         }
-    },
+    }],
     "ghcr.io/hal7df/borealos-nvidia-open": [{
         "type": "sigstoreSigned",
         "keyPath": "/etc/pki/containers/borealos.pub",
         "signedIdentity": {
             "type": "matchRepository"
         }
-    }
-]}' </usr/etc/containers/policy.json)"
+    }]
+}' </usr/etc/containers/policy.json)"
 
 cp /tmp/cosign.pub /etc/pki/containers/borealos.pub
 tee /etc/containers/registries.d/borealos.yaml <<EOF

--- a/build-files/system-files.sh
+++ b/build-files/system-files.sh
@@ -3,7 +3,7 @@ cat /tmp/just/*.just >> /usr/share/ublue-os/just/60-custom.just
 
 # Disable unattended installation of flatpaks on user sign in
 SYS_FLATPAK_AUTOINSTALL_MSG="# Disabled to avoid changing the system software install without user consent. The below command can be run manually if desired."
-sed -i "s/^\\(ujust install-system-flatpaks\\)/$SYS_FLATPAK_AUTOINSTALL_MSG\n#\\1"\
+sed -i "s/^\\(ujust install-system-flatpaks\\)/$SYS_FLATPAK_AUTOINSTALL_MSG\n#\\1/"\
     /usr/libexec/ublue-flatpak-manager
 
 # Modify flatpak management to use the borealos flatpak list


### PR DESCRIPTION
The command to splice the BorealOS signing keys into `/etc/containers/policy.json` was creating an empty policy file due to bad syntax in the `jq` command used to do so. This fixes the `jq` command so the policy should be written correctly now.

Relatedly, this also fixes a syntax error in a `sed` command in `system-files.sh`.