### PR TITLE
chore(ci): build images on Tuesdays to align with upstream

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: '05 10 * * 0'  # 10:05am UTC every Sunday
+    - cron: '05 5 * * 2'  # 5:05am UTC every Tuesday
   push:
     branches:
       - main


### PR DESCRIPTION
Upstream Aurora has been building its stable images on Tuesdays since ublue-os/aurora#1202. This moves borealos to build at 5:05AM UTC on Tuesdays to ensure that build timestamps align (the reported image build date in GRUB currently does not align with the borealos image tag, which can be misleading).