### PR TITLE
fix(build-iso): correct key reference for cosign public key

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -246,7 +246,7 @@ build-iso image=repo_name tag="stable" ghcr="0" clean="0":
         IMAGE_FULL="$IMAGE_REGISTRY/{{ image }}:{{ tag }}"
 
         # Verify the downloaded container
-        just verify-container "{{ image }}:{{ tag }}" "${IMAGE_REGISTRY}" "https://raw.githubusercontent.com/{{ repo_user }}/{{ repo_name }}/refs/heads/main/cosign.pub"
+        just verify-container "{{ image }}:{{ tag }}" "${IMAGE_REGISTRY}" "https://raw.githubusercontent.com/{{ repo_user }}/{{ repo_name }}/refs/heads/main/conf/usr/lib/pki/containers/borealos.pub"
     else
         IMAGE_REGISTRY="localhost"
         IMAGE_FULL="$IMAGE_REGISTRY/{{ image }}:{{ tag }}"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Run the following steps, then reboot:
 ```sh
 # Fetch the BorealOS public signing key
 sudo mkdir -p /etc/pki/containers
-sudo curl -Lo /etc/pki/containers/borealos.pub https://raw.githubusercontent.com/hal7df/borealos/refs/heads/main/cosign.pub
+sudo curl -Lo /etc/pki/containers/borealos.pub https://raw.githubusercontent.com/hal7df/borealos/refs/heads/main/conf/usr/lib/pki/containers/borealos.pub
 
 # Add a signature policy for BorealOS (you only need to run the command for the image you plan to rebase to)
 sudo podman image trust -t sigstoreSigned -f /etc/pki/containers/borealos.pub ghcr.io/hal7df/borealos


### PR DESCRIPTION
A reference to the cosign public key (used when verifying the image download for the ISO installer) was not updated following its move into `conf/`, this corrects all remaining references.