### PR TITLE
fix(ci): use rootless podman for all building and rechunking, re-add missing stable tag

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -53,16 +53,12 @@ jobs:
 
       - name: Build and rechunk container image
         shell: bash
-        run: sudo just build ${{ matrix.image }}
-
-      - name: Read image tags
-        id: get_tags
-        if: ${{ github.ref == 'refs/heads/main' }}
-        shell: bash
+        id: build
         run: |
-          tags="$(just list-tags ${{ matrix.image }})"
-          echo "tags=$tags" | tr '[[:space:]]' ' ' >> $GITHUB_OUTPUT
-          echo $GITHUB_OUTPUT
+          just build ${{ matrix.image }}
+          podman image ls --filter 'reference=${{ matrix.image }}'
+          TAGS=($(podman image ls --filter 'reference=${{ matrix.image }}' --format '{{ .Tag }}'))
+          echo "tags=${TAGS[*]}" | tee "$GITHUB_OUTPUT"
 
       - name: Fix registry case issues
         id: registry_case
@@ -86,7 +82,7 @@ jobs:
           attempt_delay: 15000
           with: |
             image: ${{ matrix.image }}
-            tags: ${{ steps.get_tags.outputs.tags }}
+            tags: ${{ steps.build.outputs.tags }}
             registry: ${{ steps.registry_case.outputs.lowercase }}
             username: ${{ env.REGISTRY_USER }}
             password: ${{ env.REGISTRY_PASSWORD }}

--- a/Containerfile
+++ b/Containerfile
@@ -50,3 +50,13 @@ RUN --mount=type=tmpfs,dst=/var/log \
 RUN bootc container lint
 LABEL containers.bootc=1
 
+# Add static metadata
+LABEL org.opencontainers.image.title="${TARGET_IMAGE}"
+LABEL org.opencontainers.image.version="${VERSION}"
+LABEL org.opencontainers.image.description="Custom lightweight build of Aurora Linux targeted at power users"
+LABEL org.opencontainers.image.url="https://github.com/hal7df/borealos"
+LABEL org.opencontainers.image.source="https://raw.githubusercontent.com/hal7df/borealos/refs/heads/main/Containerfile"
+LABEL org.opencontainers.image.vendor="hal7df"
+
+LABEL io.artifacthub.package.maintainers="[{\"name\":\"hal7df\",\"email\":\"hal7df@gmail.com\"}]"
+LABEL io.artifacthub.package.readme-url="https://raw.githubusercontent.com/hal7df/borealos/refs/heads/main/README.md"

--- a/Justfile
+++ b/Justfile
@@ -110,6 +110,9 @@ build image=repo_name $SOURCE_TAG="stable" $DEST_TAG="stable":
 
     just rechunk "$TARGET_IMAGE" "$TARGET_TAG" "$DEST_TAG"
 
+    # Add symbolic tag to rechunked image
+    ${PODMAN} image tag "${TARGET_IMAGE}:${TARGET_TAG%-unopt}" "${TARGET_IMAGE}:${DEST_TAG}"
+
 [private]
 rechunk image=repo_name $tag="stable-unopt" prevTag="stable":
     #!/usr/bin/env bash
@@ -138,8 +141,8 @@ rechunk image=repo_name $tag="stable-unopt" prevTag="stable":
         --label ostree.final-diffid- \
         --tag "{{ image }}:$OUT_TAG" | ${PODMAN} load
 
-    # Remove the unoptimized image
-    ${PODMAN} rmi "{{ image }}:${tag}"
+    # Remove unoptimized image
+    podman image rm "{{ image }}:${tag}"
 
 # Build ISO
 [group('Boot Media')]
@@ -368,8 +371,3 @@ verify-container container="" registry="ghcr.io/ublue-os" $key="":
         echo "Verification of {{ registry }}/{{ container }} failed. Please ensure the container's public key is correct."
         exit 1
     fi
-
-[group('Image')]
-list-tags image=repo_name:
-    #!/usr/bin/env bash
-    podman image ls --filter reference='{{ image }}' --format "{{ '{{.Tag}}' }}"

--- a/Justfile
+++ b/Justfile
@@ -82,15 +82,7 @@ build image=repo_name $SOURCE_TAG="stable" $DEST_TAG="stable":
     TARGET_TAG="${TARGET_TAG}-unopt"
 
     BUILD_ARGS+=("--file" "Containerfile")
-    BUILD_ARGS+=("--label" "org.opencontainers.image.title={{ image }}")
-    BUILD_ARGS+=("--label" "org.opencontainers.image.version=${IMAGE_VERSION}")
     BUILD_ARGS+=("--label" "org.opencontainers.image.revision=$(git rev-parse HEAD))")
-    BUILD_ARGS+=("--label" "org.opencontainers.image.description={{ image_desc }}")
-    BUILD_ARGS+=("--label" "org.opencontainers.image.url=https://github.com/hal7df/borealos")
-    BUILD_ARGS+=("--label" "org.opencontainers.image.source=https://raw.githubusercontent.com/hal7df/borealos/refs/heads/main/Containerfile")
-    BUILD_ARGS+=("--label" "org.opencontainers.image.vendor=hal7df")
-    BUILD_ARGS+=("--label" "io.artifacthub.package.maintainers=[{\"name\":\"hal7df\",\"email\":\"hal7df@gmail.com\"}]")
-    BUILD_ARGS+=("--label" "io.artifacthub.package.readme-url=https://raw.githubusercontent.com/hal7df/borealos/refs/heads/main/README.md")
     BUILD_ARGS+=("--label" "ostree.linux=$(jq -r '.Labels["ostree.linux"]' < /tmp/inspect-{{ image }}.json)")
     BUILD_ARGS+=("--build-arg" "SOURCE_IMAGE=$SOURCE_IMAGE")
     BUILD_ARGS+=("--build-arg" "SOURCE_TAG=$SOURCE_TAG")


### PR DESCRIPTION
Fixes missing images by running all build and rechunk processes in rootless podman (as rootful podman is no longer needed for rechunking). This also fixes the missing `stable` tag on the latest images.

Also includes some other minor cleanup tasks:
  - Moves most image metadata into the Containerfile to keep the build command short
  - Folds the `get_tags` workflow step into the build and rechunk step, now that there is no need to pass images between rootful and rootless Podman.
    - Removes the `list-tags` Just recipe, this is now handled directly in the workflow.