### PR TITLE
fix(updates): link borealos pubkey in /etc for older container policies

### DIFF
--- a/scripts/03-pubkey-migration.sh
+++ b/scripts/03-pubkey-migration.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+mkdir -p /etc/pki/containers
+ln -s /usr/lib/pki/containers/borealos.pub /etc/pki/containers/borealos.pub

--- a/scripts/20-branding.sh
+++ b/scripts/20-branding.sh
@@ -44,5 +44,3 @@ sed -i "s;\(https://\)getaurora.dev;\1${IMAGE_GIT_REPO};g" /usr/lib/os-release
 sed -i 's;aurora\(-dx\)*\("\)*$;borealos\2;g' /usr/lib/os-release
 sed -i "s;\(RELEASE_TYPE=\).*\$;\1${TARGET_RELEASE_TYPE};g" /usr/lib/os-release
 sed -i "s;${BASE_IMAGE_VERSION};${VERSION};g" /usr/lib/os-release
-
-cp /usr/lib/os-release /etc/os-release

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,6 +8,8 @@ fi
 # Required by some RPM installs
 mkdir -p /var/lib/alternatives
 
+set -euo pipefail
+
 find "${SCRIPTS_DIR}" -maxdepth 1 -iname "*-*.sh" -type f | sort --sort=human-numeric | while read -r SCRIPT; do
     printf '::script:: ==%s==\n' "$(basename "$SCRIPT")"
     "$(realpath "$SCRIPT")"


### PR DESCRIPTION
Moving `borealos.pub` to `/usr/lib/pki/containers` unexpectedly deleted the corresponding file from `/etc` on existing installs, stranding users with older container policies. This symlinks the public key to the old path to allow upgrades to work with older policies.

# Fixing manual installations
This will not address installations that are already stranded; the fix will need to be applied manually in these cases. This can be done by manually running one of the following commands (either will work):

1. `sudo cp -f /usr/etc/containers/policy.json /etc/containers/policy.json`
2. `sudo ln -s /usr/lib/pki/containers/borealos.pub /etc/pki/containers/borealos.pub`

# Other fixes
The revamp to the build system dropped the `set -e` from the top-level build script, causing silent failures in the build modules. This issue has now been corrected (and silent build failures resolved).