### PR TITLE
feat: add tailscale back to the image

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,6 @@ flatpak, brew, or manually installing them to ~/.local/bin/.
   Flatpak if needed.
 - Thunderbird: space concerns
 - Podman Desktop: space concerns
-- Tailscale/KTailctl: I currently have no use for tailscale.
 - Flatseal: KDE has its own Flatpak permissions manager, available in System
   Settings under Security & Privacy > Application Permissions > Flatpak Permissions.
 - Mission Center: Removed in favor of KDE's System Monitor application.

--- a/packages.json
+++ b/packages.json
@@ -30,8 +30,7 @@
             "python3-s3transfer",
             "python3-ramalama",
             "solaar",
-            "Sunshine",
-            "tailscale"
+            "Sunshine"
         ]
     }
 }


### PR DESCRIPTION
Adds the Tailscale package back to the image. KTailCtl is still not included, if needed it can be installed from Flathub.