### PR TITLE
fix(Justfile): reduce length of chunkah command line

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -131,7 +131,7 @@ rechunk image=repo_name $tag="stable-unopt" prevTag="stable":
         --prune /sysroot/ \
         --label ostree.commit- \
         --label ostree.final-diffid- \
-        --config "$CHUNKAH_CONFIG" \
+        --config "/chunkah-config.json" \
         --tag "{{ image }}:$OUT_TAG" | ${PODMAN} load
 
     # Remove unoptimized image

--- a/Justfile
+++ b/Justfile
@@ -116,12 +116,14 @@ rechunk image=repo_name $tag="stable-unopt" prevTag="stable":
 
     # Set metadata for the image
     OUT_TAG="${tag/%-unopt/}"
-    CHUNKAH_CONFIG_STR=$(${PODMAN} inspect "{{ image }}:${tag}")
-    export CHUNKAH_CONFIG_STR
+
+    CHUNKAH_CONFIG_FILE="$(mktemp)"
+    trap 'rm -f $CHUNKAH_CONFIG' EXIT
+    ${PODMAN} inspect "{{ image }}:${tag}" | jq 'map(pick(.Config))' > "$CHUNKAH_CONFIG"
 
     # Rechunk the image
     ${PODMAN} run --rm --mount=type=image,src="{{ image }}:${tag}",target=/chunkah \
-        -e CHUNKAH_CONFIG_STR \
+        -v "${CHUNKAH_CONFIG_FILE}:/chunkah-config.json:ro,Z" \
         "{{ chunkah }}" build \
         --verbose \
         --compressed \
@@ -129,6 +131,7 @@ rechunk image=repo_name $tag="stable-unopt" prevTag="stable":
         --prune /sysroot/ \
         --label ostree.commit- \
         --label ostree.final-diffid- \
+        --config "$CHUNKAH_CONFIG" \
         --tag "{{ image }}:$OUT_TAG" | ${PODMAN} load
 
     # Remove unoptimized image

--- a/Justfile
+++ b/Justfile
@@ -118,8 +118,8 @@ rechunk image=repo_name $tag="stable-unopt" prevTag="stable":
     OUT_TAG="${tag/%-unopt/}"
 
     CHUNKAH_CONFIG_FILE="$(mktemp)"
-    trap 'rm -f $CHUNKAH_CONFIG' EXIT
-    ${PODMAN} inspect "{{ image }}:${tag}" | jq 'map(pick(.Config))' > "$CHUNKAH_CONFIG"
+    trap 'rm -f $CHUNKAH_CONFIG_FILE' EXIT
+    ${PODMAN} inspect "{{ image }}:${tag}" | jq 'map(pick(.Config))' > "$CHUNKAH_CONFIG_FILE"
 
     # Rechunk the image
     ${PODMAN} run --rm --mount=type=image,src="{{ image }}:${tag}",target=/chunkah \


### PR DESCRIPTION
The output of `podman inspect ${IMAGE}` was becoming too long to pass via the command line. This filters down the inspect output to just the `Config` element that Chunkah requires, and passes the config string via file rather than over the command line.