### PR TITLE
Fix image signatures, harden CI pipeline

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -32,24 +32,17 @@ jobs:
         image: ${{ fromJson(inputs.images) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Maximize build space
+        uses: ublue-os/remove-unwanted-software@695eb75bc387dbcd9685a8e72d23439d8686cba6 #v10
 
       - name: Install Just
-        shell: bash
-        run: |
-          set -euxo pipefail
-          JUST_VERSION=$(curl -L https://api.github.com/repos/casey/just/releases/latest | jq -r '.tag_name')
-          curl -sSLO https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz
-          tar xzvf just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz -C /tmp just
-          sudo mv /tmp/just /usr/local/bin/just
-          rm -f just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 #v4.0.0
 
       - name: Lint Justfile
         shell: bash
         run: just lint
-
-      - name: Maximize build space
-        uses: ublue-os/remove-unwanted-software@v9
 
       - name: Build and rechunk container image
         shell: bash
@@ -60,57 +53,44 @@ jobs:
           TAGS=($(podman image ls --filter 'reference=${{ matrix.image }}' --format '{{ .Tag }}'))
           echo "tags=${TAGS[*]}" | tee "$GITHUB_OUTPUT"
 
-      - name: Fix registry case issues
-        id: registry_case
-        if: ${{ github.ref == 'refs/heads/main' }}
-        uses: ASzc/change-string-case-action@v8
-        with:
-          string: ${{ env.IMAGE_REGISTRY }}
-
-      # Retry the container upload up to 3 times, as it is prone to fail on
-      # occasion
-      - name: Push to ghcr.io
-        uses: Wandalen/wretry.action@v3.8.0
-        id: push
-        if: ${{ github.ref == 'refs/heads/main' }}
-        env:
-          REGISTRY_USER: ${{ github.actor }}
-          REGISTRY_PASSWORD: ${{ github.token }}
-        with:
-          action: redhat-actions/push-to-registry@v3
-          attempt_limit: 3
-          attempt_delay: 15000
-          with: |
-            image: ${{ matrix.image }}
-            tags: ${{ steps.build.outputs.tags }}
-            registry: ${{ steps.registry_case.outputs.lowercase }}
-            username: ${{ env.REGISTRY_USER }}
-            password: ${{ env.REGISTRY_PASSWORD }}
-            extra-args: |
-              --compression-format=zstd
-
-      - name: Login to ghcr.io for signature upload
-        uses: docker/login-action@v4
-        if: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' }}
+      - name: Login to ghcr.io
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 #v4.5.1
+        if: ${{ github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
+      - name: Push to ghcr.io
+        if: ${{ github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+        id: push
+        env:
+          TAGS: ${{ steps.build.outputs.tags }}
+        run: |
+          set -euxo pipefail
+
+          for TAG in ${TAGS}; do
+            podman push --digestfile=/tmp/digestfile "${{ matrix.image }}:${TAG}" "${{ env.REGISTRY }}/${{ matrix.image }}:${TAG}"
+          done
+
+          digest="$(cat /tmp/digestfile)"
+
+          echo "digest=${digest}" | tee -a "$GITHUB_OUTPUT"
+
       - name: Install cosign
         uses: sigstore/cosign-installer@v4.1.2
-        if: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' }}
+        if: ${{ github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
 
       - name: Sign container image
-        if: ${{ github.ref == 'refs/heads/main' && github.event_name != 'pull_request' }}
+        if: ${{ github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
         shell: bash
         env:
-          TAGS: ${{ steps.push.outputs.outputs && fromJSON(steps.push.outputs.outputs).digest }}
+          DIGEST: ${{ steps.push.outputs.digest }}
           COSIGN_EXPERIMENTAL: false
           COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
         run: |
           cosign sign -y --key env://COSIGN_PRIVATE_KEY --new-bundle-format=false \
-          --use-signing-config=false ${{ steps.registry_case.outputs.lowercase }}/${{ matrix.image }}@${TAGS}
+            --use-signing-config=false ${{ env.REGISTRY }}/${{ matrix.image }}@${DIGEST}
 
   check:
     name: Check all images built successfully

--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -50,37 +50,31 @@ jobs:
         image: ${{ fromJson (inputs.images) }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Maximize build space
+        uses: ublue-os/remove-unwanted-software@695eb75bc387dbcd9685a8e72d23439d8686cba6 #v10
 
       - name: Install Just
-        shell: bash
-        run: |
-          set -euxo pipefail
-          JUST_VERSION=$(curl -L https://api.github.com/repos/casey/just/releases/latest | jq -r '.tag_name')
-          curl -sSLO https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz
-          tar xzvf just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz -C /tmp just
-          sudo mv /tmp/just /usr/local/bin/just
-          rm -f just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz
+        uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 #v4.0.0
 
       - name: Lint Justfile
         shell: bash
         run: just lint
 
-      - name: Maximize build space
-        uses: ublue-os/remove-unwanted-software@v9
-
       - name: Build ISO
         id: iso
         shell: bash
         run: |
-          sudo just build-iso ${{ matrix.image }} ${{ inputs.tag }} 1 1
+          JUST="$(command -v just)"
+          sudo --preserve-env=PATH "${JUST}" build-iso ${{ matrix.image }} ${{ inputs.tag }} 1 1
           ls -l build/output/${{ matrix.image }}-${{ inputs.tag }}.iso
           awk '{printf "sha256=%s\n", $1}' build/output/${{ matrix.image }}-${{ inputs.tag }}.iso.sha256 >> $GITHUB_OUTPUT
           echo $GITHUB_OUTPUT
 
       - name: Upload ISO as job artifact
         id: upload
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
           name: ${{ matrix.image }}-${{ inputs.tag }}.iso


### PR DESCRIPTION
# Fixes
- Use `podman push` directly in a shell step instead of using `redhat-actions/push-to-registry` to push the OS image to GHCR
- Use `extractions/setup-just` for installing `just` in the CI workflow for improved reliability

# Improvements
- All external actions are now hash-pinned