### PR TITLE
fix(ci): update runners to ubuntu 26.04

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   build-image:
     name: Build ${{ matrix.image }}:${{ inputs.source_tag }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     continue-on-error: false
     permissions:
       contents: read

--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -39,7 +39,7 @@ jobs:
     name: Build ISO installers for ${{ matrix.image }}:${{ inputs.tag }}
     outputs:
       url: ${{ steps.upload.outputs.artifact-url }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
The version of Podman currently installed on the Ubuntu 24.04 Actions runner image [has some problems](https://github.com/actions/runner-images/pull/14621), which may be the source of the build failures. This upgrades the CI image to Ubuntu 26.04, which uses the Ubuntu-packaged Podman version and has [not had issues elsewhere](https://github.com/ublue-os/image-template/pull/268).