### PR TITLE
Remove incus-client

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -16,6 +16,7 @@
             "docker-model-plugin",
             "incus",
             "incus-agent",
+            "incus-client",
             "lxc",
             "mariadb",
             "mariadb-backup",


### PR DESCRIPTION
The current package list removes `incus` and `incus-agent`, but not `incus-cilent`. This removes `incus-client`, which itself is just shy of 25MiB installed.