### PR TITLE
maybe-fix(ci): use skopeo to push the container image instead of podman

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -71,9 +71,9 @@ jobs:
           set -euxo pipefail
 
           for TAG in $TAGS; do
-            podman push --digestfile=/tmp/digestfile \
-              "${{ matrix.image }}:${{ steps.build.outputs.src }}" \
-              "${{ env.IMAGE_REGISTRY }}/${{ matrix.image }}:${TAG}"
+            skopeo copy --digestfile=/tmp/digestfile \
+              "container-storage:localhost/${{ matrix.image }}:${{ steps.build.outputs.src }}" \
+              "docker://${{ env.IMAGE_REGISTRY }}/${{ matrix.image }}:${TAG}"
           done
 
           digest="$(cat /tmp/digestfile)"


### PR DESCRIPTION
The issue with mismatching image digests may be related to Podman, so this switches the push implementation to `skopeo` instead, which anecdotally does not seem to be affected by the mismatched digest issue.